### PR TITLE
Add CI workflow for PR from development to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,16 @@
 name: CI Workflow
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
+    # Nur wenn der PR von "development" auf "master" geht:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**.md'
 
 jobs:
   ci-check:
+    if: github.head_ref == 'development'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Modifizieren Sie Ihre CI-Pipeline so, dass sie nur noch ausgeführt wird, wenn ein «Pull Request» vom «development» auf den «master» Branch erstellt wird.

